### PR TITLE
Declare style exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   },
   "exports": {
     ".": {
+      "style": "./lib/style.css",
       "import": "./lib/index.js",
       "require": "./umd/index.js"
     },


### PR DESCRIPTION
This allows importing the library simply as "v-network-graph" from CSS:

```css
@import 'v-network-graph';
```

It does require a bundler, but most people using Vue will be using a bundler... Even if they don't, this change shouldn't break anything, it's just an additional declaration.